### PR TITLE
fix: stringify each template directive

### DIFF
--- a/packages/parser/src/stringifier.ts
+++ b/packages/parser/src/stringifier.ts
@@ -271,14 +271,18 @@ class _Stringifier {
         if (eachDirective) {
           props.push(
             this.writer.withTemp(() => {
-              this.writer.write(`@each={${eachDirective.alias.name} in `);
-              if (!eachDirective.index) {
-                this.writer.write(eachDirective.iterator.name);
-              } else {
+              this.writer.write(`@each={`);
+
+              if (eachDirective.index) {
                 this.writer.write(
-                  `(${eachDirective.iterator.name}, ${eachDirective.index.name})`
+                  `(${eachDirective.alias.name}, ${eachDirective.index.name})`
                 );
+              } else {
+                this.writer.write(eachDirective.alias.name);
               }
+
+              this.writer.write(` in ${eachDirective.iterator.name}`);
+
               this.writer.write(`}`);
             })
           );

--- a/packages/parser/src/tests/stringifier.test.ts
+++ b/packages/parser/src/tests/stringifier.test.ts
@@ -78,6 +78,21 @@ describe('Stringifier', () => {
             each: t.elementEach({
               iterator: t.identifier({ name: 'posts' }),
               alias: t.identifier({ name: 'post' }),
+              index: t.identifier({ name: 'i' }),
+            }),
+          })
+        )
+      ).toEqual(`<div @each={(post, i) in posts} />`);
+
+      expect(
+        Stringifier.toString(
+          t.tagTemplate({
+            tag: 'div',
+            props: {},
+            children: [],
+            each: t.elementEach({
+              iterator: t.identifier({ name: 'posts' }),
+              alias: t.identifier({ name: 'post' }),
             }),
           })
         )


### PR DESCRIPTION
Fixes a bug in stringifier when there's an `each` directive on a template with an `index` variable specified