### PR TITLE
feat: improve environment store

### DIFF
--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -93,7 +93,10 @@ export class ComponentViewEvaluator {
                 })
               );
 
-              this.env.set('$$children', slot);
+              this.env.set('$$children', {
+                value: slot,
+                readonly: true,
+              });
 
               component.props.forEach((prop) => {
                 const getPropValue = () => {
@@ -124,7 +127,10 @@ export class ComponentViewEvaluator {
                     .join(' ');
                 }
 
-                this.env.set(prop.name, propValue);
+                this.env.set(prop.name, {
+                  value: propValue,
+                  readonly: true,
+                });
               });
             });
           }
@@ -132,10 +138,10 @@ export class ComponentViewEvaluator {
           if (!this.rekaComponentStateComputation) {
             this.rekaComponentStateComputation = computed(() => {
               component.state.forEach((val) => {
-                this.env.set(
-                  val.name,
-                  this.tree.computeExpr(val.init, this.env)
-                );
+                this.env.set(val.name, {
+                  value: this.tree.computeExpr(val.init, this.env),
+                  readonly: false,
+                });
               });
             });
           }

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -10,6 +10,8 @@ type ComponentViewTreeComputationCache = {
   computed: IComputedValue<t.RekaComponentView[] | t.ExternalComponentView[]>;
 };
 
+export const ComponentSlotBindingKey = Symbol('$$children');
+
 export class ComponentViewEvaluator {
   private declare resolveComponentComputation: IComputedValue<
     t.RekaComponentView[] | t.ErrorSystemView[] | t.ExternalComponentView[]
@@ -93,7 +95,7 @@ export class ComponentViewEvaluator {
                 })
               );
 
-              this.env.set('$$children', {
+              this.env.set(ComponentSlotBindingKey, {
                 value: slot,
                 readonly: true,
               });

--- a/packages/core/src/environment.ts
+++ b/packages/core/src/environment.ts
@@ -1,10 +1,28 @@
 import * as t from '@rekajs/types';
+import { getRandomId, invariant } from '@rekajs/utils';
 import { action, makeObservable, observable } from 'mobx';
 
 import { Reka } from './reka';
 
+type EnvironmentValue =
+  | string
+  | number
+  | boolean
+  | Record<string, any>
+  | Array<any>
+  | t.Component;
+
+type Binding = {
+  value: EnvironmentValue;
+  readonly: boolean;
+};
+
+type BindingKey = string;
+
 export class Environment {
-  bindings: Map<string, any>;
+  id = getRandomId();
+
+  bindings: Map<BindingKey, Binding>;
 
   constructor(readonly reka: Reka, readonly parent?: Environment) {
     this.bindings = new Map();
@@ -16,25 +34,51 @@ export class Environment {
     });
   }
 
-  set(name: string, value: any, reassignment?: boolean) {
-    if (!reassignment) {
-      this.bindings.set(name, value);
+  reassign(identifier: t.Identifier, value: any) {
+    const distance = this.reka.resolver.getDistance(identifier);
+
+    if (distance === undefined) {
+      throw new Error();
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let env: Environment = this;
+
+    for (let i = 0; i < distance; i++) {
+      const parent = env.parent;
+
+      if (!parent) {
+        return undefined;
+      }
+
+      env = parent;
+    }
+
+    const binding = env.bindings.get(identifier.name);
+
+    if (!binding) {
+      throw new Error();
+    }
+
+    if (binding.readonly) {
+      // TODO: handle error
+      console.warn(
+        `Cannot reassign readonly value "${identifier.name}" (${identifier.id})`
+      );
       return;
     }
 
-    if (this.bindings.get(name) !== undefined) {
-      this.bindings.set(name, value);
-      return;
-    }
-
-    if (!this.parent) {
-      return;
-    }
-
-    return this.parent.set(name, value, reassignment);
+    return env.bindings.set(identifier.name, {
+      ...binding,
+      value,
+    });
   }
 
-  delete(name: string) {
+  set(name: BindingKey, binding: Binding) {
+    this.bindings.set(name, binding);
+  }
+
+  delete(name: BindingKey) {
     const binding = this.bindings.get(name);
     if (!binding) {
       return;
@@ -43,12 +87,12 @@ export class Environment {
     this.bindings.delete(name);
   }
 
-  getByName(name: string, external?: boolean) {
+  getByName(name: BindingKey, external?: boolean) {
     if (external) {
       return this.reka.externals.get(name);
     }
 
-    const v = this.bindings.get(name);
+    const v = this.bindings.get(name)?.value;
 
     if (v !== undefined) {
       return v;
@@ -85,7 +129,7 @@ export class Environment {
       env = parent;
     }
 
-    return env.getByName(identifier.name);
+    return env.bindings.get(identifier.name)?.value;
   }
 
   inherit() {

--- a/packages/core/src/environment.ts
+++ b/packages/core/src/environment.ts
@@ -17,7 +17,7 @@ type Binding = {
   readonly: boolean;
 };
 
-type BindingKey = string;
+type BindingKey = string | Symbol;
 
 export class Environment {
   id = getRandomId();
@@ -89,6 +89,8 @@ export class Environment {
 
   getByName(name: BindingKey, external?: boolean) {
     if (external) {
+      invariant(typeof name === 'string', 'Invalid external binding key');
+
       return this.reka.externals.get(name);
     }
 

--- a/packages/core/src/evaluator.ts
+++ b/packages/core/src/evaluator.ts
@@ -9,7 +9,7 @@ import {
   runInAction,
 } from 'mobx';
 
-import { ComponentViewEvaluator } from './component';
+import { ComponentSlotBindingKey, ComponentViewEvaluator } from './component';
 import { Environment } from './environment';
 import { computeExpression } from './expression';
 import { Frame } from './frame';
@@ -401,7 +401,7 @@ export class ViewEvaluator {
       t.slotView({
         key: createKey(ctx.path),
         template,
-        children: ctx.env.getByName('$$children'),
+        children: ctx.env.getByName(ComponentSlotBindingKey),
       }),
     ];
   }

--- a/packages/core/src/evaluator.ts
+++ b/packages/core/src/evaluator.ts
@@ -333,10 +333,16 @@ export class ViewEvaluator {
 
             iteratorCache = {
               computed: computed(() => {
-                inheritedEnv.set(eachExpr.alias.name, value);
+                inheritedEnv.set(eachExpr.alias.name, {
+                  value,
+                  readonly: true,
+                });
 
                 if (eachExpr.index) {
-                  inheritedEnv.set(eachExpr.index.name, i);
+                  inheritedEnv.set(eachExpr.index.name, {
+                    value: i,
+                    readonly: true,
+                  });
                 }
 
                 return renderTemplate(template, {

--- a/packages/core/src/expression.ts
+++ b/packages/core/src/expression.ts
@@ -69,7 +69,10 @@ export const computeExpression = (
   }
 
   if (expr instanceof t.Val) {
-    env.set(expr.name, computeExpression(expr.init, reka, env));
+    env.set(expr.name, {
+      value: computeExpression(expr.init, reka, env),
+      readonly: false,
+    });
     return;
   }
 
@@ -84,21 +87,13 @@ export const computeExpression = (
 
     switch (expr.operator) {
       case '=': {
-        return env.set(expr.left.name, right, true);
+        return env.reassign(expr.left, right);
       }
       case '+=': {
-        return env.set(
-          expr.left.name,
-          env.getByIdentifier(expr.left) + right,
-          true
-        );
+        return env.reassign(expr.left, env.getByIdentifier(expr.left) + right);
       }
       case '-=': {
-        return env.set(
-          expr.left.name,
-          env.getByIdentifier(expr.left) - right,
-          true
-        );
+        return env.reassign(expr.left, env.getByIdentifier(expr.left) - right);
       }
     }
   }
@@ -116,7 +111,7 @@ export const computeExpression = (
       const blockEnv = env.inherit();
 
       expr.params.forEach((param, i) => {
-        env.set(param.name, args[i]);
+        env.set(param.name, { value: args[i], readonly: true });
       });
 
       let returnValue: any;

--- a/packages/core/src/reka.ts
+++ b/packages/core/src/reka.ts
@@ -128,10 +128,10 @@ export class Reka {
       this.syncGlobals = computed(
         () => {
           this.program.globals.forEach((global) => {
-            this.env.set(
-              global.name,
-              computeExpression(global.init, this as any, this.env)
-            );
+            this.env.set(global.name, {
+              value: computeExpression(global.init, this as any, this.env),
+              readonly: false,
+            });
           });
         },
         {
@@ -144,7 +144,7 @@ export class Reka {
       this.syncComponents = computed(
         () => {
           this.program.components.forEach((component) => {
-            this.env.set(component.name, component);
+            this.env.set(component.name, { value: component, readonly: true });
           });
         },
         {


### PR DESCRIPTION
This PR introduces some improvements to the `Environment` store:-

- Introduces readonly environment values, reassignment to these values are not allowed:
```tsx
component App(prop1) => (
  <button onClick={() => {
      prop1 = "newValue"; // not allowed; no effect
  }) />
)
```

- Uses unique Symbol to store/access component slot value