### PR TITLE
feat: add view owner

### DIFF
--- a/.changeset/warm-tomatoes-do.md
+++ b/.changeset/warm-tomatoes-do.md
@@ -1,0 +1,6 @@
+---
+'@rekajs/core': patch
+'@rekajs/types': patch
+---
+
+Add owner in View

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -78,6 +78,7 @@ export class ComponentViewEvaluator {
         component,
         render: [],
         template: this.template,
+        owner: this.ctx.owner,
       });
 
       untracked(() => {
@@ -95,6 +96,7 @@ export class ComponentViewEvaluator {
                     this.evaluator.computeTemplate(child, {
                       ...this.ctx,
                       path: [...this.ctx.path, child.id],
+                      owner: this.ctx.owner,
                     })
                   );
 
@@ -169,6 +171,7 @@ export class ComponentViewEvaluator {
               render = this.evaluator.computeTemplate(component.template, {
                 path: [this.key, 'root'],
                 env: this.env,
+                owner: componentViewTree,
               });
             } catch (err) {
               render = [
@@ -177,6 +180,7 @@ export class ComponentViewEvaluator {
                   error: String(err),
                   template: this.template,
                   key: this.key,
+                  owner: componentViewTree,
                 }),
               ];
             }
@@ -237,6 +241,7 @@ export class ComponentViewEvaluator {
                 error: `Component "${this.template.component.name}" not found`,
                 key: this.key,
                 template: this.template,
+                owner: this.ctx.owner,
               }),
             ];
           }

--- a/packages/core/src/evaluator.ts
+++ b/packages/core/src/evaluator.ts
@@ -22,6 +22,7 @@ import { createKey } from './utils';
 
 export type TemplateEvaluateContext = {
   env: Environment;
+  owner: t.ComponentView | null;
   path: string[];
 };
 
@@ -143,6 +144,9 @@ export class Evaluator {
               }
             },
           },
+          TagView: {
+            exclude: ['owner'],
+          },
           ComponentView: {
             exclude: ['component'],
           },
@@ -177,7 +181,11 @@ export class Evaluator {
 
       this.viewObserver = new Observer(view, {
         id: `view-${this.rootTemplate.id}`,
-        shouldIgnoreObservable: (_, __, value) => {
+        shouldIgnoreObservable: (_, key, value) => {
+          if (key === 'owner') {
+            return true;
+          }
+
           if (value instanceof t.Template || value instanceof t.Component) {
             return true;
           }
@@ -372,6 +380,7 @@ export class Evaluator {
         template,
         children: ctx.env.getByName(ComponentSlotBindingKey),
         frame: this.frame.id,
+        owner: ctx.owner,
       }),
     ];
   }
@@ -413,6 +422,7 @@ export class Evaluator {
         key: createKey(ctx.path),
         template,
         frame: this.frame.id,
+        owner: ctx.owner,
       });
     } catch (error: any) {
       // TODO: create error handling system
@@ -422,6 +432,7 @@ export class Evaluator {
         error: String(error),
         template,
         frame: this.frame.id,
+        owner: ctx.owner,
       });
     }
 
@@ -467,6 +478,7 @@ export class Evaluator {
       const views = this.computeTemplate(this.rootTemplate, {
         path: ['frame'],
         env: this.reka.head.env,
+        owner: null,
       });
 
       return t.assert(views[0], t.RekaComponentView);

--- a/packages/types/src/generated/types.generated.ts
+++ b/packages/types/src/generated/types.generated.ts
@@ -443,12 +443,14 @@ type TagViewParameters = {
   tag: string;
   children: View[];
   props: Record<string, any>;
+  owner: ComponentView | null;
 };
 
 export class TagView extends View {
   declare tag: string;
   declare children: View[];
   declare props: Record<string, any>;
+  declare owner: ComponentView | null;
   constructor(value: TagViewParameters) {
     super('TagView', value);
   }
@@ -461,10 +463,12 @@ type ComponentViewParameters = {
   template: Template;
   frame: string;
   component: Component;
+  owner?: ComponentView | null;
 };
 
 export abstract class ComponentView extends View {
   declare component: Component;
+  declare owner: ComponentView | null;
   constructor(type: string, value: ComponentViewParameters) {
     super(type, value);
   }
@@ -477,6 +481,7 @@ type RekaComponentViewParameters = {
   template: Template;
   frame: string;
   component: Component;
+  owner?: ComponentView | null;
   render: View[];
 };
 
@@ -493,6 +498,7 @@ type ExternalComponentViewParameters = {
   key: string;
   template: Template;
   frame: string;
+  owner?: ComponentView | null;
   component: ExternalComponent;
   props: Record<string, string | number | boolean | Function>;
 };
@@ -512,10 +518,12 @@ type SlotViewParameters = {
   template: Template;
   frame: string;
   children: View[];
+  owner: ComponentView | null;
 };
 
 export class SlotView extends View {
   declare children: View[];
+  declare owner: ComponentView | null;
   constructor(value: SlotViewParameters) {
     super('SlotView', value);
   }
@@ -527,9 +535,11 @@ type SystemViewParameters = {
   key: string;
   template: Template;
   frame: string;
+  owner: ComponentView | null;
 };
 
 export abstract class SystemView extends View {
+  declare owner: ComponentView | null;
   constructor(type: string, value: SystemViewParameters) {
     super(type, value);
   }
@@ -541,6 +551,7 @@ type EachSystemViewParameters = {
   key: string;
   template: Template;
   frame: string;
+  owner: ComponentView | null;
   children: View[];
 };
 
@@ -557,6 +568,7 @@ type ErrorSystemViewParameters = {
   key: string;
   template: Template;
   frame: string;
+  owner: ComponentView | null;
   error: string;
 };
 

--- a/packages/types/src/types.definition.ts
+++ b/packages/types/src/types.definition.ts
@@ -240,6 +240,7 @@ Schema.define('TagView', {
     tag: t.string,
     children: t.array(t.node('View')),
     props: t.map(t.any),
+    owner: t.union(t.node('ComponentView'), t.nullish),
   }),
 });
 
@@ -248,6 +249,7 @@ Schema.define('ComponentView', {
   extends: 'View',
   fields: (t) => ({
     component: t.node('Component'),
+    owner: t.defaultValue(t.union(t.node('ComponentView'), t.nullish), null),
   }),
 });
 
@@ -270,12 +272,16 @@ Schema.define('SlotView', {
   extends: 'View',
   fields: (t) => ({
     children: t.array(t.node('View')),
+    owner: t.union(t.node('ComponentView'), t.nullish),
   }),
 });
 
 Schema.define('SystemView', {
   abstract: true,
   extends: 'View',
+  fields: (t) => ({
+    owner: t.union(t.node('ComponentView'), t.nullish),
+  }),
 });
 
 Schema.define('EachSystemView', {


### PR DESCRIPTION
This PR adds a new `owner` property to the rendered `View`. 

The `owner` property specifies which parent `ComponentView` was responsible for rendering the current `View`. 

For example, given the following AST:

```tsx
component Button() => (
  <button> 
     <slot />
 </button>
)

component App() => (
  <div>
     <Button>
         <text value={"Hello!"} />
     </Button>
  </div>
)
```

The output View for `App` would be:
```tsx
{
  type: "RekaComponentView",
  id: "App", 
  component: { name: "App" },
  owner: null, // <-- The root view has no owner, because it comes from the frame itself
  render: [
    {
      type: "TagView",
      tag: "div",
      owner: { type: "RekaComponentView", id: "App" }, // <-- div tag view belongs to "App" RekaComponentView
      children: [
        {
          type: "RekaComponentView",
          id: "Button",
          component: { name: "Button" },
          owner: { type: "RekaComponentView", id: "App" }, // <-- Button component view belongs to "App" RekaComponentView 
          render: [
            {
               type: "TagView",
               tag: "button",
               owner: { type: "RekaComponentView", id: "Button" }, // <-- button tag view belongs to "Button" RekaComponentView
               children:[
                  {
                     type: "SlotView",
                     owner:  { type: "RekaComponentView", id: "Button" }, // <-- <slot> view belongs to "Button" RekaComponentView
                     children: [
                        {
                           type: "TagView",
                           tag: "text",
                           owner: { type: "RekaComponentView", id: "App" },  // <-- text tag view (via slot) belongs to "App" RekaComponentView
                           props: {
                              value: "Hello!",
                           },
                        }
                     ] 
                  }
               ]
            }
          ],
        },
      ],
    },
  ],
}
```

