### PR TITLE
fix: nested object expressions as props in ExternalComponents

### DIFF
--- a/.changeset/spicy-lamps-itch.md
+++ b/.changeset/spicy-lamps-itch.md
@@ -1,0 +1,5 @@
+---
+'@rekajs/types': patch
+---
+
+Fix nested object expressions as props in ExternalComponents

--- a/packages/types/src/generated/types.generated.ts
+++ b/packages/types/src/generated/types.generated.ts
@@ -529,13 +529,13 @@ type ExternalComponentViewParameters = {
   owner?: ComponentView | null;
   component: ExternalComponent;
   children?: View[];
-  props: Record<string, string | number | boolean | Function>;
+  props: Record<string, any>;
 };
 
 export class ExternalComponentView extends ComponentView {
   declare component: ExternalComponent;
   declare children: View[];
-  declare props: Record<string, string | number | boolean | Function>;
+  declare props: Record<string, any>;
   constructor(value: ExternalComponentViewParameters) {
     super('ExternalComponentView', value);
   }

--- a/packages/types/src/types.definition.ts
+++ b/packages/types/src/types.definition.ts
@@ -267,7 +267,7 @@ Schema.define('ExternalComponentView', {
   fields: (t) => ({
     component: t.node('ExternalComponent'),
     children: t.defaultValue(t.array(t.node('View')), []),
-    props: t.map(t.union(t.string, t.number, t.boolean, t.func)),
+    props: t.map(t.any),
   }),
 });
 


### PR DESCRIPTION
Fixes nested object expressions as props when used with ExternalComponent templates

Closes #31 