### PR TITLE
feat: Add ability to evaluate frames immediately on load (#60)

### DIFF
--- a/.changeset/famous-needles-mix.md
+++ b/.changeset/famous-needles-mix.md
@@ -1,5 +1,5 @@
 ---
-'@rekajs/core': minor
+'@rekajs/core': patch
 ---
 
 Add ability to evaluate frames immediately on load (#60)

--- a/.changeset/famous-needles-mix.md
+++ b/.changeset/famous-needles-mix.md
@@ -1,0 +1,5 @@
+---
+'@rekajs/core': minor
+---
+
+Add ability to evaluate frames immediately on load (#60)

--- a/packages/core/src/frame.ts
+++ b/packages/core/src/frame.ts
@@ -16,6 +16,7 @@ export type FrameOpts = {
   id?: string;
   component: FrameComponentConfig;
   syncImmediately?: boolean;
+  evaluateImmediately?: boolean;
 };
 
 /**
@@ -88,7 +89,7 @@ export class Frame {
   }
 
   /// Compute a View tree
-  compute(evaluateImmediately?: boolean) {
+  compute(evaluateImmediately: boolean = false) {
     const evaluate = () => {
       if (!this.sync) {
         return;

--- a/packages/core/src/frame.ts
+++ b/packages/core/src/frame.ts
@@ -88,14 +88,14 @@ export class Frame {
   }
 
   /// Compute a View tree
-  compute() {
-    return defer(async () => {
+  compute(evaluateImmediately?: boolean) {
+    const evaluate = () => {
       if (!this.sync) {
         return;
       }
-
       return this.evaluator.computeView();
-    });
+    };
+    return evaluateImmediately ? evaluate() : defer(async () => evaluate());
   }
 
   /// Update the props of the Component associated with the Frame

--- a/packages/core/src/reka.ts
+++ b/packages/core/src/reka.ts
@@ -110,8 +110,16 @@ export class Reka {
 
   /**
    * Load a new State data type
+   *
+   * @param state The State data type to load
+   * @param syncImmediately Whether to sync changes made to the State to all active Frames immediately
+   * @param evaluateImmediately Whether to evaluate Frames immediately or defer through a microtask
    */
-  load(state: t.State, syncImmediately: boolean = true) {
+  load(
+    state: t.State,
+    syncImmediately: boolean = true,
+    evaluateImmediately?: boolean
+  ) {
     if (this.loaded) {
       this.dispose();
     }
@@ -139,7 +147,7 @@ export class Reka {
     this.extensions.init();
 
     if (syncImmediately) {
-      this.sync();
+      this.sync(evaluateImmediately);
     } else {
       this.head.sync();
     }
@@ -150,13 +158,15 @@ export class Reka {
 
   /**
    * Sync changes made to the State to all active Frames. You usually do not need to call this manually
+   *
+   * @param evaluateImmediately Whether to evaluate Frames immediately or defer through a microtask
    */
-  sync() {
+  sync(evaluateImmediately?: boolean) {
     this.head.sync();
 
     return Promise.all(
       this.frames.map((frame) => {
-        return frame.compute();
+        return frame.compute(evaluateImmediately);
       })
     );
   }

--- a/packages/core/src/reka.ts
+++ b/packages/core/src/reka.ts
@@ -187,8 +187,11 @@ export class Reka {
 
   /**
    * Create a new Frame instance
+   *
+   * @param opts The Frame options
+   * @param evaluateImmediately Whether to evaluate Frames immediately or defer through a microtask
    */
-  async createFrame(opts: FrameOpts) {
+  async createFrame(opts: FrameOpts, evaluateImmediately?: boolean) {
     const frame = new Frame(opts, this);
 
     invariant(
@@ -201,7 +204,7 @@ export class Reka {
     this.frames.push(frame);
 
     if (!this.init) {
-      await frame.compute();
+      await frame.compute(evaluateImmediately);
     }
 
     return frame;

--- a/packages/core/src/reka.ts
+++ b/packages/core/src/reka.ts
@@ -118,7 +118,7 @@ export class Reka {
   load(
     state: t.State,
     syncImmediately: boolean = true,
-    evaluateImmediately?: boolean
+    evaluateImmediately: boolean = false
   ) {
     if (this.loaded) {
       this.dispose();
@@ -161,7 +161,7 @@ export class Reka {
    *
    * @param evaluateImmediately Whether to evaluate Frames immediately or defer through a microtask
    */
-  sync(evaluateImmediately?: boolean) {
+  sync(evaluateImmediately: boolean = false) {
     this.head.sync();
 
     return Promise.all(
@@ -187,11 +187,8 @@ export class Reka {
 
   /**
    * Create a new Frame instance
-   *
-   * @param opts The Frame options
-   * @param evaluateImmediately Whether to evaluate Frames immediately or defer through a microtask
    */
-  async createFrame(opts: FrameOpts, evaluateImmediately?: boolean) {
+  async createFrame(opts: FrameOpts) {
     const frame = new Frame(opts, this);
 
     invariant(
@@ -204,7 +201,7 @@ export class Reka {
     this.frames.push(frame);
 
     if (!this.init) {
-      await frame.compute(evaluateImmediately);
+      await frame.compute(opts.evaluateImmediately);
     }
 
     return frame;


### PR DESCRIPTION
Discussion in #60, task was to add a flag to evaluate frames immediately without a microtask.