### PR TITLE
feat: add ability to specify variable type

### DIFF
--- a/.changeset/purple-scissors-vanish.md
+++ b/.changeset/purple-scissors-vanish.md
@@ -1,0 +1,6 @@
+---
+'@rekajs/parser': patch
+'@rekajs/types': patch
+---
+
+Add ability to specify variable kind

--- a/packages/parser/src/context.ts
+++ b/packages/parser/src/context.ts
@@ -3,7 +3,7 @@ export class TokContext {
 }
 
 export const tc_val_prop = new TokContext('val-prop');
-export const tc_input = new TokContext('input');
+export const tc_kind = new TokContext('kind');
 export const tc_component = new TokContext('component');
 export const tc_component_prop_start = new TokContext('component-prop-start');
 export const tc_component_prop_end = new TokContext('component-prop-end');

--- a/packages/parser/src/context.ts
+++ b/packages/parser/src/context.ts
@@ -2,7 +2,11 @@ export class TokContext {
   constructor(readonly contextName: string) {}
 }
 
+export const tc_val_prop = new TokContext('val-prop');
+export const tc_input = new TokContext('input');
 export const tc_component = new TokContext('component');
+export const tc_component_prop_start = new TokContext('component-prop-start');
+export const tc_component_prop_end = new TokContext('component-prop-end');
 export const tc_component_tmpl = new TokContext('component-template');
 export const tc_element_open_tag = new TokContext('<el');
 export const tc_element_close_tag = new TokContext('</el');

--- a/packages/parser/src/lexer.ts
+++ b/packages/parser/src/lexer.ts
@@ -3,7 +3,7 @@ import {
   tc_component_tmpl,
   tc_element_open_tag,
   tc_element_expr,
-  tc_input,
+  tc_kind,
   tc_val_prop,
   tc_component_prop_start,
 } from './context';
@@ -121,8 +121,8 @@ export class Lexer {
         return this.tokenize(TokenType.EQ);
       }
       case '<': {
-        if (this.currentContext === tc_input) {
-          return this.tokenize(TokenType.INPUT_PARAM_START);
+        if (this.currentContext === tc_kind) {
+          return this.tokenize(TokenType.KIND_PARAM_START);
         }
 
         if (
@@ -139,8 +139,8 @@ export class Lexer {
         return this.tokenize(TokenType.LT);
       }
       case '>': {
-        if (this.currentContext === tc_input) {
-          return this.tokenize(TokenType.INPUT_PARAM_END);
+        if (this.currentContext === tc_kind) {
+          return this.tokenize(TokenType.KIND_PARAM_END);
         }
 
         if (this.currentContext === tc_element_open_tag) {
@@ -164,7 +164,7 @@ export class Lexer {
       }
       case ':': {
         if (this.currentContext === tc_val_prop) {
-          return this.tokenize(TokenType.INPUT);
+          return this.tokenize(TokenType.KIND);
         }
 
         return this.tokenize(TokenType.COLON);
@@ -229,8 +229,8 @@ export class Lexer {
       return this.tokenize(keyword);
     }
 
-    if (this.currentContext === tc_input) {
-      return this.tokenize(TokenType.INPUT_TYPE);
+    if (this.currentContext === tc_kind) {
+      return this.tokenize(TokenType.KIND_TYPE);
     }
 
     if (this.currentContext === tc_element_open_tag) {
@@ -276,19 +276,19 @@ export class Lexer {
         break;
       }
 
-      case TokenType.INPUT: {
-        this.state.addContext(tc_input);
+      case TokenType.KIND: {
+        this.state.addContext(tc_kind);
 
         break;
       }
       case TokenType.EQ: {
-        if (this.currentContext === tc_input) {
+        if (this.currentContext === tc_kind) {
           this.state.popContext();
         }
         break;
       }
       case TokenType.SEMICOLON: {
-        if (this.currentContext === tc_input) {
+        if (this.currentContext === tc_kind) {
           this.state.popContext();
         }
 
@@ -318,7 +318,7 @@ export class Lexer {
         break;
       }
       case TokenType.RPAREN: {
-        if (this.currentContext === tc_input) {
+        if (this.currentContext === tc_kind) {
           this.state.popContext();
         }
 

--- a/packages/parser/src/lexer.ts
+++ b/packages/parser/src/lexer.ts
@@ -3,6 +3,9 @@ import {
   tc_component_tmpl,
   tc_element_open_tag,
   tc_element_expr,
+  tc_input,
+  tc_val_prop,
+  tc_component_prop_start,
 } from './context';
 import { State } from './state';
 import { KEYWORDS, Token, TokenType } from './tokens';
@@ -78,12 +81,12 @@ export class Lexer {
 
     switch (c) {
       case '(': {
-        if (
-          this.currentToken?.type === TokenType.ARROW &&
-          this.currentContext === tc_component
-        ) {
-          return this.tokenize(TokenType.COMPONENT_TMPL_START);
+        if (this.currentContext === tc_component) {
+          if (this.currentToken?.type === TokenType.ARROW) {
+            return this.tokenize(TokenType.COMPONENT_TMPL_START);
+          }
         }
+
         return this.tokenize(TokenType.LPAREN);
       }
       case ')': {
@@ -118,6 +121,10 @@ export class Lexer {
         return this.tokenize(TokenType.EQ);
       }
       case '<': {
+        if (this.currentContext === tc_input) {
+          return this.tokenize(TokenType.INPUT_PARAM_START);
+        }
+
         if (
           this.currentContext === tc_component_tmpl ||
           this.currentContext === tc_element_open_tag
@@ -132,6 +139,10 @@ export class Lexer {
         return this.tokenize(TokenType.LT);
       }
       case '>': {
+        if (this.currentContext === tc_input) {
+          return this.tokenize(TokenType.INPUT_PARAM_END);
+        }
+
         if (this.currentContext === tc_element_open_tag) {
           return this.tokenize(TokenType.ELEMENT_TAG_END);
         }
@@ -150,6 +161,13 @@ export class Lexer {
         const string = this.tokenize(TokenType.STRING);
         this.state.current += 1;
         return string;
+      }
+      case ':': {
+        if (this.currentContext === tc_val_prop) {
+          return this.tokenize(TokenType.INPUT);
+        }
+
+        return this.tokenize(TokenType.COLON);
       }
       case ';': {
         return this.tokenize(TokenType.SEMICOLON);
@@ -211,6 +229,10 @@ export class Lexer {
       return this.tokenize(keyword);
     }
 
+    if (this.currentContext === tc_input) {
+      return this.tokenize(TokenType.INPUT_TYPE);
+    }
+
     if (this.currentContext === tc_element_open_tag) {
       return this.tokenize(TokenType.ELEMENT_PROPERTY);
     }
@@ -249,8 +271,65 @@ export class Lexer {
 
   private updateContext() {
     switch (this.state.currentToken?.type) {
+      case TokenType.VAL: {
+        this.state.addContext(tc_val_prop);
+        break;
+      }
+
+      case TokenType.INPUT: {
+        this.state.addContext(tc_input);
+
+        break;
+      }
+      case TokenType.EQ: {
+        if (this.currentContext === tc_input) {
+          this.state.popContext();
+        }
+        break;
+      }
+      case TokenType.SEMICOLON: {
+        if (this.currentContext === tc_input) {
+          this.state.popContext();
+        }
+
+        if (this.currentContext == tc_val_prop) {
+          this.state.popContext();
+        }
+
+        break;
+      }
       case TokenType.COMPONENT: {
         this.state.addContext(tc_component);
+        break;
+      }
+      case TokenType.LPAREN: {
+        // At the start of a component definition
+        // component name(...)
+        if (
+          this.currentContext === tc_component &&
+          this.previousToken.type === TokenType.IDENTIFIER
+        ) {
+          this.state.addContext(tc_component_prop_start);
+
+          // TODO: should probably add an explicit "prop" keyword
+          this.state.addContext(tc_val_prop);
+        }
+
+        break;
+      }
+      case TokenType.RPAREN: {
+        if (this.currentContext === tc_input) {
+          this.state.popContext();
+        }
+
+        if (this.currentContext === tc_val_prop) {
+          this.state.popContext();
+        }
+
+        if (this.currentContext === tc_component_prop_start) {
+          this.state.popContext();
+        }
+
         break;
       }
       case TokenType.COMPONENT_TMPL_START: {

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -35,6 +35,33 @@ const parseExpressionWithAcornToRekaType = <T extends t.Type = t.Any>(
   return { expression, type };
 };
 
+const getJSObjFromExpr = (obj: b.ObjectExpression) => {
+  return obj.properties.reduce((accum, property) => {
+    b.assertProperty(property);
+
+    b.assertLiteral(property.value);
+
+    let key: string | undefined;
+
+    if (b.isIdentifier(property.key)) {
+      key = property.key.name;
+    }
+
+    // Acorn's Literal type is more generic than Babel's
+    // @ts-ignore
+    if (property.key.type === 'Literal') {
+      key = (property.key as any).value;
+    }
+
+    invariant(key, 'Property Key not defined');
+
+    return {
+      ...accum,
+      [key]: (property.value as any).value ?? '',
+    };
+  }, {});
+};
+
 const jsToReka = <T extends t.ASTNode = t.ASTNode>(
   node: b.Node,
   opts?: AcornParserOptions<T>
@@ -287,15 +314,76 @@ class _Parser extends Lexer {
     return declarations;
   }
 
+  private parseInputType() {
+    const inputType = this.consume(TokenType.INPUT_TYPE).value;
+
+    if (
+      inputType === 'string' ||
+      inputType === 'number' ||
+      inputType === 'boolean'
+    ) {
+      return t.primitiveInput({
+        kind: inputType,
+      });
+    }
+
+    if (inputType === 'array') {
+      this.consume(TokenType.INPUT_PARAM_START);
+
+      const param = this.parseInputType();
+
+      this.consume(TokenType.INPUT_PARAM_END);
+
+      return t.arrayInput({
+        param,
+      });
+    }
+
+    if (inputType === 'enum') {
+      this.consume(TokenType.INPUT_PARAM_START);
+      const startToken = this.currentToken;
+
+      while (!this.match(TokenType.INPUT_PARAM_END)) {
+        this.next();
+      }
+
+      const endToken = this.previousToken;
+
+      const str = this.source.slice(startToken.pos, endToken.pos);
+      const expr = parseWithAcorn(str, 0);
+
+      b.assertObjectExpression(expr);
+
+      const values = getJSObjFromExpr(expr);
+
+      return t.enumInput({
+        values,
+      });
+    }
+
+    throw new Error();
+  }
+
+  private parseInput() {
+    if (!this.match(TokenType.INPUT)) {
+      return;
+    }
+
+    return this.parseInputType();
+  }
+
   private parseVariableDecl() {
     this.consume(TokenType.VAL);
     const name = this.consume(TokenType.IDENTIFIER);
+    const input = this.parseInput();
+
     this.consume(TokenType.EQ);
     const init = this.parseExpressionAt(this.currentToken.pos - 1) as any;
     this.consume(TokenType.SEMICOLON);
 
     return t.val({
       name: name.value,
+      input,
       init,
     });
   }
@@ -307,54 +395,59 @@ class _Parser extends Lexer {
 
     this.consume(TokenType.LPAREN);
 
-    const startToken = this.currentToken;
+    const props: t.ComponentProp[] = [];
 
-    while (!this.check(TokenType.RPAREN)) {
-      if (this.check(TokenType.LPAREN)) {
-        while (!this.check(TokenType.RPAREN)) {
+    while (!this.match(TokenType.RPAREN)) {
+      const propName = this.consume(TokenType.IDENTIFIER).value;
+
+      const input = this.parseInput();
+
+      let init: t.Expression | undefined;
+
+      if (this.match(TokenType.EQ)) {
+        const startToken = this.currentToken;
+
+        let parenCount = 0;
+
+        while (
+          !this.check(TokenType.COMMA) &&
+          !(this.check(TokenType.RPAREN) && parenCount == 0)
+        ) {
+          if (this.check(TokenType.LPAREN)) {
+            parenCount++;
+          }
+
+          if (this.check(TokenType.RPAREN)) {
+            parenCount--;
+          }
+
           this.next();
         }
+
+        const endToken = this.currentToken;
+
+        let startTokenPos = startToken.pos;
+        const endTokenPos = endToken.pos;
+
+        if (startToken.type === TokenType.STRING) {
+          startTokenPos--;
+        }
+
+        const exprString = `(${this.source.slice(startTokenPos, endTokenPos)})`;
+
+        init = parseExpressionWithAcornToRekaType(exprString, 0).type;
       }
 
-      this.next();
-    }
-
-    const endToken = this.currentToken;
-
-    const paramsStr = this.source.slice(startToken.pos, endToken.pos);
-
-    const parsedDummyFn = parseWithAcorn(`function (${paramsStr}) {}`, 0);
-
-    invariant(b.isFunctionExpression(parsedDummyFn), 'Not function expr');
-
-    const props = parsedDummyFn.params.map((param) => {
-      let init: t.Expression | undefined;
-      let name: string;
-
-      invariant(
-        b.isAssignmentPattern(param) || b.isIdentifier(param),
-        'Invalid component prop'
+      props.push(
+        t.componentProp({
+          name: propName,
+          init,
+          input,
+        })
       );
 
-      if (b.isAssignmentPattern(param)) {
-        init = jsToReka(param.right, { expectedType: t.Expression });
-
-        invariant(
-          b.isIdentifier(param.left),
-          'Invalid component prop assignment'
-        );
-        name = param.left.name;
-      } else {
-        name = param.name;
-      }
-
-      return t.componentProp({
-        name,
-        init,
-      });
-    });
-
-    this.consume(TokenType.RPAREN);
+      this.match(TokenType.COMMA);
+    }
 
     const state = this.parseComponentStateDeclaration();
     this.consume(TokenType.ARROW);

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -314,36 +314,36 @@ class _Parser extends Lexer {
     return declarations;
   }
 
-  private parseInputType() {
-    const inputType = this.consume(TokenType.INPUT_TYPE).value;
+  private parseKindType() {
+    const kindType = this.consume(TokenType.KIND_TYPE).value;
 
     if (
-      inputType === 'string' ||
-      inputType === 'number' ||
-      inputType === 'boolean'
+      kindType === 'string' ||
+      kindType === 'number' ||
+      kindType === 'boolean'
     ) {
-      return t.primitiveInput({
-        kind: inputType,
+      return t.primitiveKind({
+        primitive: kindType,
       });
     }
 
-    if (inputType === 'array') {
-      this.consume(TokenType.INPUT_PARAM_START);
+    if (kindType === 'array') {
+      this.consume(TokenType.KIND_PARAM_START);
 
-      const param = this.parseInputType();
+      const param = this.parseKindType();
 
-      this.consume(TokenType.INPUT_PARAM_END);
+      this.consume(TokenType.KIND_PARAM_END);
 
-      return t.arrayInput({
+      return t.arrayKind({
         param,
       });
     }
 
-    if (inputType === 'enum') {
-      this.consume(TokenType.INPUT_PARAM_START);
+    if (kindType === 'enum') {
+      this.consume(TokenType.KIND_PARAM_START);
       const startToken = this.currentToken;
 
-      while (!this.match(TokenType.INPUT_PARAM_END)) {
+      while (!this.match(TokenType.KIND_PARAM_END)) {
         this.next();
       }
 
@@ -356,7 +356,7 @@ class _Parser extends Lexer {
 
       const values = getJSObjFromExpr(expr);
 
-      return t.enumInput({
+      return t.enumKind({
         values,
       });
     }
@@ -364,18 +364,18 @@ class _Parser extends Lexer {
     throw new Error();
   }
 
-  private parseInput() {
-    if (!this.match(TokenType.INPUT)) {
+  private parseKind() {
+    if (!this.match(TokenType.KIND)) {
       return;
     }
 
-    return this.parseInputType();
+    return this.parseKindType();
   }
 
   private parseVariableDecl() {
     this.consume(TokenType.VAL);
     const name = this.consume(TokenType.IDENTIFIER);
-    const input = this.parseInput();
+    const kind = this.parseKind();
 
     this.consume(TokenType.EQ);
     const init = this.parseExpressionAt(this.currentToken.pos - 1) as any;
@@ -383,7 +383,7 @@ class _Parser extends Lexer {
 
     return t.val({
       name: name.value,
-      input,
+      kind,
       init,
     });
   }
@@ -400,7 +400,7 @@ class _Parser extends Lexer {
     while (!this.match(TokenType.RPAREN)) {
       const propName = this.consume(TokenType.IDENTIFIER).value;
 
-      const input = this.parseInput();
+      const kind = this.parseKind();
 
       let init: t.Expression | undefined;
 
@@ -442,7 +442,7 @@ class _Parser extends Lexer {
         t.componentProp({
           name: propName,
           init,
-          input,
+          kind,
         })
       );
 

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -330,12 +330,12 @@ class _Parser extends Lexer {
     if (kindType === 'array') {
       this.consume(TokenType.KIND_PARAM_START);
 
-      const param = this.parseKindType();
+      const kind = this.parseKindType();
 
       this.consume(TokenType.KIND_PARAM_END);
 
       return t.arrayKind({
-        param,
+        kind,
       });
     }
 

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -339,7 +339,7 @@ class _Parser extends Lexer {
       });
     }
 
-    if (kindType === 'enum') {
+    if (kindType === 'option') {
       this.consume(TokenType.KIND_PARAM_START);
       const startToken = this.currentToken;
 
@@ -354,10 +354,10 @@ class _Parser extends Lexer {
 
       b.assertObjectExpression(expr);
 
-      const values = getJSObjFromExpr(expr);
+      const options = getJSObjFromExpr(expr);
 
-      return t.enumKind({
-        values,
+      return t.optionKind({
+        options,
       });
     }
 

--- a/packages/parser/src/stringifier.ts
+++ b/packages/parser/src/stringifier.ts
@@ -8,15 +8,15 @@ import { Writer, WriterResult } from './writer';
 class _Stringifier {
   writer: Writer = new Writer();
 
-  private stringifyInput(input: t.Input) {
-    const _stringifyInputType = (input: t.Input) => {
-      if (t.is(input, t.PrimitiveInput)) {
-        this.writer.write(input.kind);
+  private stringifyInput(input: t.Kind) {
+    const _stringifyInputType = (input: t.Kind) => {
+      if (t.is(input, t.PrimitiveKind)) {
+        this.writer.write(input.primitive);
 
         return;
       }
 
-      if (t.is(input, t.ArrayInput)) {
+      if (t.is(input, t.ArrayKind)) {
         this.writer.write(`array<`);
         _stringifyInputType(input.param);
         this.writer.write('>');
@@ -24,7 +24,7 @@ class _Stringifier {
         return;
       }
 
-      if (t.is(input, t.EnumInput)) {
+      if (t.is(input, t.EnumKind)) {
         this.writer.write('enum<');
         this.writer.write(JSON.stringify(input.values));
         this.writer.write('>');
@@ -176,8 +176,8 @@ class _Stringifier {
       Val: (node) => {
         this.writer.write(`val ${node.name}`);
 
-        if (node.input) {
-          this.stringifyInput(node.input);
+        if (node.kind) {
+          this.stringifyInput(node.kind);
         }
 
         if (node.init) {
@@ -208,8 +208,8 @@ class _Stringifier {
       ComponentProp: (node) => {
         this.writer.write(node.name);
 
-        if (node.input) {
-          this.stringifyInput(node.input);
+        if (node.kind) {
+          this.stringifyInput(node.kind);
         }
 
         if (node.init) {

--- a/packages/parser/src/stringifier.ts
+++ b/packages/parser/src/stringifier.ts
@@ -18,7 +18,7 @@ class _Stringifier {
 
       if (t.is(input, t.ArrayKind)) {
         this.writer.write(`array<`);
-        _stringifyInputType(input.param);
+        _stringifyInputType(input.kind);
         this.writer.write('>');
 
         return;

--- a/packages/parser/src/stringifier.ts
+++ b/packages/parser/src/stringifier.ts
@@ -24,9 +24,9 @@ class _Stringifier {
         return;
       }
 
-      if (t.is(input, t.EnumKind)) {
-        this.writer.write('enum<');
-        this.writer.write(JSON.stringify(input.values));
+      if (t.is(input, t.OptionKind)) {
+        this.writer.write('option<');
+        this.writer.write(JSON.stringify(input.options));
         this.writer.write('>');
       }
     };

--- a/packages/parser/src/stringifier.ts
+++ b/packages/parser/src/stringifier.ts
@@ -8,6 +8,33 @@ import { Writer, WriterResult } from './writer';
 class _Stringifier {
   writer: Writer = new Writer();
 
+  private stringifyInput(input: t.Input) {
+    const _stringifyInputType = (input: t.Input) => {
+      if (t.is(input, t.PrimitiveInput)) {
+        this.writer.write(input.kind);
+
+        return;
+      }
+
+      if (t.is(input, t.ArrayInput)) {
+        this.writer.write(`array<`);
+        _stringifyInputType(input.param);
+        this.writer.write('>');
+
+        return;
+      }
+
+      if (t.is(input, t.EnumInput)) {
+        this.writer.write('enum<');
+        this.writer.write(JSON.stringify(input.values));
+        this.writer.write('>');
+      }
+    };
+
+    this.writer.write(`:`);
+    _stringifyInputType(input);
+  }
+
   toString(node: t.ASTNode) {
     this.stringify(node);
 
@@ -149,6 +176,10 @@ class _Stringifier {
       Val: (node) => {
         this.writer.write(`val ${node.name}`);
 
+        if (node.input) {
+          this.stringifyInput(node.input);
+        }
+
         if (node.init) {
           this.writer.write(' = ');
           this.stringify(node.init);
@@ -176,6 +207,10 @@ class _Stringifier {
       },
       ComponentProp: (node) => {
         this.writer.write(node.name);
+
+        if (node.input) {
+          this.stringifyInput(node.input);
+        }
 
         if (node.init) {
           this.writer.write(`=`);

--- a/packages/parser/src/tests/parser.test.ts
+++ b/packages/parser/src/tests/parser.test.ts
@@ -86,7 +86,7 @@ describe('Parser', () => {
       Parser.parseProgram(`
       val color: string = "blue";
       val colors: array<string> = ["blue"];
-      val option: enum<{blue: "Blue", red: "Red"}> = "red";
+      val option: option<{blue: "Blue", red: "Red"}> = "red";
     `)
     ).toMatchObject({
       type: 'Program',
@@ -122,8 +122,8 @@ describe('Parser', () => {
           type: 'Val',
           name: 'option',
           kind: {
-            type: 'EnumKind',
-            values: {
+            type: 'OptionKind',
+            options: {
               blue: 'Blue',
               red: 'Red',
             },

--- a/packages/parser/src/tests/parser.test.ts
+++ b/packages/parser/src/tests/parser.test.ts
@@ -108,7 +108,7 @@ describe('Parser', () => {
           name: 'colors',
           kind: {
             type: 'ArrayKind',
-            param: {
+            kind: {
               type: 'PrimitiveKind',
               primitive: 'string',
             },

--- a/packages/parser/src/tests/parser.test.ts
+++ b/packages/parser/src/tests/parser.test.ts
@@ -81,4 +81,59 @@ describe('Parser', () => {
       ],
     });
   });
+  it('should be able to parse variable kind', () => {
+    expect(
+      Parser.parseProgram(`
+      val color: string = "blue";
+      val colors: array<string> = ["blue"];
+      val option: enum<{blue: "Blue", red: "Red"}> = "red";
+    `)
+    ).toMatchObject({
+      type: 'Program',
+      globals: [
+        {
+          type: 'Val',
+          name: 'color',
+          kind: {
+            type: 'PrimitiveKind',
+            primitive: 'string',
+          },
+          init: {
+            type: 'Literal',
+            value: 'blue',
+          },
+        },
+        {
+          type: 'Val',
+          name: 'colors',
+          kind: {
+            type: 'ArrayKind',
+            param: {
+              type: 'PrimitiveKind',
+              primitive: 'string',
+            },
+          },
+          init: {
+            type: 'ArrayExpression',
+            elements: [{ type: 'Literal', value: 'blue' }],
+          },
+        },
+        {
+          type: 'Val',
+          name: 'option',
+          kind: {
+            type: 'EnumKind',
+            values: {
+              blue: 'Blue',
+              red: 'Red',
+            },
+          },
+          init: {
+            type: 'Literal',
+            value: 'red',
+          },
+        },
+      ],
+    });
+  });
 });

--- a/packages/parser/src/tests/stringifier.test.ts
+++ b/packages/parser/src/tests/stringifier.test.ts
@@ -172,7 +172,7 @@ describe('Stringifier', () => {
         t.val({
           name: 'colors',
           kind: t.arrayKind({
-            param: t.primitiveKind({
+            kind: t.primitiveKind({
               primitive: 'string',
             }),
           }),

--- a/packages/parser/src/tests/stringifier.test.ts
+++ b/packages/parser/src/tests/stringifier.test.ts
@@ -159,8 +159,8 @@ describe('Stringifier', () => {
       Stringifier.toString(
         t.val({
           name: 'color',
-          input: t.primitiveInput({
-            kind: 'string',
+          kind: t.primitiveKind({
+            primitive: 'string',
           }),
           init: t.literal({ value: 'blue' }),
         })
@@ -171,9 +171,9 @@ describe('Stringifier', () => {
       Stringifier.toString(
         t.val({
           name: 'colors',
-          input: t.arrayInput({
-            param: t.primitiveInput({
-              kind: 'string',
+          kind: t.arrayKind({
+            param: t.primitiveKind({
+              primitive: 'string',
             }),
           }),
           init: t.arrayExpression({ elements: [t.literal({ value: 'blue' })] }),
@@ -185,7 +185,7 @@ describe('Stringifier', () => {
       Stringifier.toString(
         t.val({
           name: 'colors',
-          input: t.enumInput({
+          kind: t.enumKind({
             values: {
               blue: 'Blue',
               red: 'Red',

--- a/packages/parser/src/tests/stringifier.test.ts
+++ b/packages/parser/src/tests/stringifier.test.ts
@@ -154,4 +154,49 @@ describe('Stringifier', () => {
       })
     );
   });
+  it('should be able to stringify vals with input types', () => {
+    expect(
+      Stringifier.toString(
+        t.val({
+          name: 'color',
+          input: t.primitiveInput({
+            kind: 'string',
+          }),
+          init: t.literal({ value: 'blue' }),
+        })
+      )
+    ).toEqual(`val color:string = "blue"`);
+
+    expect(
+      Stringifier.toString(
+        t.val({
+          name: 'colors',
+          input: t.arrayInput({
+            param: t.primitiveInput({
+              kind: 'string',
+            }),
+          }),
+          init: t.arrayExpression({ elements: [t.literal({ value: 'blue' })] }),
+        })
+      )
+    ).toEqual(`val colors:array<string> = ["blue"]`);
+
+    expect(
+      Stringifier.toString(
+        t.val({
+          name: 'colors',
+          input: t.enumInput({
+            values: {
+              blue: 'Blue',
+              red: 'Red',
+              green: 'Green',
+            },
+          }),
+          init: t.literal({ value: 'blue' }),
+        })
+      )
+    ).toEqual(
+      `val colors:enum<{"blue":"Blue","red":"Red","green":"Green"}> = "blue"`
+    );
+  });
 });

--- a/packages/parser/src/tests/stringifier.test.ts
+++ b/packages/parser/src/tests/stringifier.test.ts
@@ -185,8 +185,8 @@ describe('Stringifier', () => {
       Stringifier.toString(
         t.val({
           name: 'colors',
-          kind: t.enumKind({
-            values: {
+          kind: t.optionKind({
+            options: {
               blue: 'Blue',
               red: 'Red',
               green: 'Green',
@@ -196,7 +196,7 @@ describe('Stringifier', () => {
         })
       )
     ).toEqual(
-      `val colors:enum<{"blue":"Blue","red":"Red","green":"Green"}> = "blue"`
+      `val colors:option<{"blue":"Blue","red":"Red","green":"Green"}> = "blue"`
     );
   });
 });

--- a/packages/parser/src/tokens.ts
+++ b/packages/parser/src/tokens.ts
@@ -30,10 +30,10 @@ export enum TokenType {
   NUMBER = 'number',
   FUNC = 'func',
 
-  INPUT = 'input',
-  INPUT_TYPE = 'input_type',
-  INPUT_PARAM_START = 'input_param_start',
-  INPUT_PARAM_END = 'input_param_end',
+  KIND = 'kind',
+  KIND_TYPE = 'kind_type',
+  KIND_PARAM_START = 'kind_param_start',
+  KIND_PARAM_END = 'kind_param_end',
 
   IF = 'if',
   IN = 'in',

--- a/packages/parser/src/tokens.ts
+++ b/packages/parser/src/tokens.ts
@@ -9,6 +9,7 @@ export enum TokenType {
   DOT = '.',
   MINUS = '-',
   PLUS = '+',
+  COLON = ':',
   SEMICOLON = ';',
   SLASH = '/',
   STAR = '*',
@@ -28,6 +29,11 @@ export enum TokenType {
   STRING = 'string',
   NUMBER = 'number',
   FUNC = 'func',
+
+  INPUT = 'input',
+  INPUT_TYPE = 'input_type',
+  INPUT_PARAM_START = 'input_param_start',
+  INPUT_PARAM_END = 'input_param_end',
 
   IF = 'if',
   IN = 'in',

--- a/packages/types/src/generated/builder.generated.ts
+++ b/packages/types/src/generated/builder.generated.ts
@@ -8,8 +8,9 @@ export const primitiveKind = (
 ) => new t.PrimitiveKind(...args);
 export const arrayKind = (...args: ConstructorParameters<typeof t.ArrayKind>) =>
   new t.ArrayKind(...args);
-export const enumKind = (...args: ConstructorParameters<typeof t.EnumKind>) =>
-  new t.EnumKind(...args);
+export const optionKind = (
+  ...args: ConstructorParameters<typeof t.OptionKind>
+) => new t.OptionKind(...args);
 export const literal = (...args: ConstructorParameters<typeof t.Literal>) =>
   new t.Literal(...args);
 export const identifier = (

--- a/packages/types/src/generated/builder.generated.ts
+++ b/packages/types/src/generated/builder.generated.ts
@@ -3,14 +3,13 @@ export const state = (...args: ConstructorParameters<typeof t.State>) =>
   new t.State(...args);
 export const program = (...args: ConstructorParameters<typeof t.Program>) =>
   new t.Program(...args);
-export const primitiveInput = (
-  ...args: ConstructorParameters<typeof t.PrimitiveInput>
-) => new t.PrimitiveInput(...args);
-export const arrayInput = (
-  ...args: ConstructorParameters<typeof t.ArrayInput>
-) => new t.ArrayInput(...args);
-export const enumInput = (...args: ConstructorParameters<typeof t.EnumInput>) =>
-  new t.EnumInput(...args);
+export const primitiveKind = (
+  ...args: ConstructorParameters<typeof t.PrimitiveKind>
+) => new t.PrimitiveKind(...args);
+export const arrayKind = (...args: ConstructorParameters<typeof t.ArrayKind>) =>
+  new t.ArrayKind(...args);
+export const enumKind = (...args: ConstructorParameters<typeof t.EnumKind>) =>
+  new t.EnumKind(...args);
 export const literal = (...args: ConstructorParameters<typeof t.Literal>) =>
   new t.Literal(...args);
 export const identifier = (

--- a/packages/types/src/generated/builder.generated.ts
+++ b/packages/types/src/generated/builder.generated.ts
@@ -3,6 +3,14 @@ export const state = (...args: ConstructorParameters<typeof t.State>) =>
   new t.State(...args);
 export const program = (...args: ConstructorParameters<typeof t.Program>) =>
   new t.Program(...args);
+export const primitiveInput = (
+  ...args: ConstructorParameters<typeof t.PrimitiveInput>
+) => new t.PrimitiveInput(...args);
+export const arrayInput = (
+  ...args: ConstructorParameters<typeof t.ArrayInput>
+) => new t.ArrayInput(...args);
+export const enumInput = (...args: ConstructorParameters<typeof t.EnumInput>) =>
+  new t.EnumInput(...args);
 export const literal = (...args: ConstructorParameters<typeof t.Literal>) =>
   new t.Literal(...args);
 export const identifier = (

--- a/packages/types/src/generated/types.generated.ts
+++ b/packages/types/src/generated/types.generated.ts
@@ -44,6 +44,55 @@ export class Program extends ASTNode {
 
 Schema.register('Program', Program);
 
+type InputParameters = {};
+
+export abstract class Input extends Type {
+  constructor(type: string, value: InputParameters) {
+    super(type, value);
+  }
+}
+
+Schema.register('Input', Input);
+
+type PrimitiveInputParameters = {
+  kind: 'string' | 'number' | 'boolean';
+};
+
+export class PrimitiveInput extends Input {
+  declare kind: 'string' | 'number' | 'boolean';
+  constructor(value: PrimitiveInputParameters) {
+    super('PrimitiveInput', value);
+  }
+}
+
+Schema.register('PrimitiveInput', PrimitiveInput);
+
+type ArrayInputParameters = {
+  param: Input;
+};
+
+export class ArrayInput extends Input {
+  declare param: Input;
+  constructor(value: ArrayInputParameters) {
+    super('ArrayInput', value);
+  }
+}
+
+Schema.register('ArrayInput', ArrayInput);
+
+type EnumInputParameters = {
+  values: Record<string, string>;
+};
+
+export class EnumInput extends Input {
+  declare values: Record<string, string>;
+  constructor(value: EnumInputParameters) {
+    super('EnumInput', value);
+  }
+}
+
+Schema.register('EnumInput', EnumInput);
+
 type ExpressionParameters = {
   meta?: Record<string, any>;
 };
@@ -104,10 +153,12 @@ type ValParameters = {
   meta?: Record<string, any>;
   name: string;
   init: Expression;
+  input?: Input | null;
 };
 
 export class Val extends Variable {
   declare init: Expression;
+  declare input: Input | null;
   constructor(value: ValParameters) {
     super('Val', value);
   }
@@ -305,10 +356,12 @@ type ComponentPropParameters = {
   meta?: Record<string, any>;
   name: string;
   init?: Expression | null;
+  input?: Input | null;
 };
 
 export class ComponentProp extends Variable {
   declare init: Expression | null;
+  declare input: Input | null;
   constructor(value: ComponentPropParameters) {
     super('ComponentProp', value);
   }
@@ -727,6 +780,10 @@ export type Any =
   | State
   | ASTNode
   | Program
+  | Input
+  | PrimitiveInput
+  | ArrayInput
+  | EnumInput
   | Expression
   | Variable
   | Literal
@@ -771,6 +828,10 @@ export type Visitor = {
   State: (node: State) => any;
   ASTNode: (node: ASTNode) => any;
   Program: (node: Program) => any;
+  Input: (node: Input) => any;
+  PrimitiveInput: (node: PrimitiveInput) => any;
+  ArrayInput: (node: ArrayInput) => any;
+  EnumInput: (node: EnumInput) => any;
   Expression: (node: Expression) => any;
   Variable: (node: Variable) => any;
   Literal: (node: Literal) => any;

--- a/packages/types/src/generated/types.generated.ts
+++ b/packages/types/src/generated/types.generated.ts
@@ -80,18 +80,18 @@ export class ArrayKind extends Kind {
 
 Schema.register('ArrayKind', ArrayKind);
 
-type EnumKindParameters = {
-  values: Record<string, string>;
+type OptionKindParameters = {
+  options: Record<string, string>;
 };
 
-export class EnumKind extends Kind {
-  declare values: Record<string, string>;
-  constructor(value: EnumKindParameters) {
-    super('EnumKind', value);
+export class OptionKind extends Kind {
+  declare options: Record<string, string>;
+  constructor(value: OptionKindParameters) {
+    super('OptionKind', value);
   }
 }
 
-Schema.register('EnumKind', EnumKind);
+Schema.register('OptionKind', OptionKind);
 
 type ExpressionParameters = {
   meta?: Record<string, any>;
@@ -783,7 +783,7 @@ export type Any =
   | Kind
   | PrimitiveKind
   | ArrayKind
-  | EnumKind
+  | OptionKind
   | Expression
   | Variable
   | Literal
@@ -831,7 +831,7 @@ export type Visitor = {
   Kind: (node: Kind) => any;
   PrimitiveKind: (node: PrimitiveKind) => any;
   ArrayKind: (node: ArrayKind) => any;
-  EnumKind: (node: EnumKind) => any;
+  OptionKind: (node: OptionKind) => any;
   Expression: (node: Expression) => any;
   Variable: (node: Variable) => any;
   Literal: (node: Literal) => any;

--- a/packages/types/src/generated/types.generated.ts
+++ b/packages/types/src/generated/types.generated.ts
@@ -68,11 +68,11 @@ export class PrimitiveKind extends Kind {
 Schema.register('PrimitiveKind', PrimitiveKind);
 
 type ArrayKindParameters = {
-  param: Kind;
+  kind: Kind;
 };
 
 export class ArrayKind extends Kind {
-  declare param: Kind;
+  declare kind: Kind;
   constructor(value: ArrayKindParameters) {
     super('ArrayKind', value);
   }

--- a/packages/types/src/generated/types.generated.ts
+++ b/packages/types/src/generated/types.generated.ts
@@ -44,54 +44,54 @@ export class Program extends ASTNode {
 
 Schema.register('Program', Program);
 
-type InputParameters = {};
+type KindParameters = {};
 
-export abstract class Input extends Type {
-  constructor(type: string, value: InputParameters) {
+export abstract class Kind extends Type {
+  constructor(type: string, value: KindParameters) {
     super(type, value);
   }
 }
 
-Schema.register('Input', Input);
+Schema.register('Kind', Kind);
 
-type PrimitiveInputParameters = {
-  kind: 'string' | 'number' | 'boolean';
+type PrimitiveKindParameters = {
+  primitive: 'string' | 'number' | 'boolean';
 };
 
-export class PrimitiveInput extends Input {
-  declare kind: 'string' | 'number' | 'boolean';
-  constructor(value: PrimitiveInputParameters) {
-    super('PrimitiveInput', value);
+export class PrimitiveKind extends Kind {
+  declare primitive: 'string' | 'number' | 'boolean';
+  constructor(value: PrimitiveKindParameters) {
+    super('PrimitiveKind', value);
   }
 }
 
-Schema.register('PrimitiveInput', PrimitiveInput);
+Schema.register('PrimitiveKind', PrimitiveKind);
 
-type ArrayInputParameters = {
-  param: Input;
+type ArrayKindParameters = {
+  param: Kind;
 };
 
-export class ArrayInput extends Input {
-  declare param: Input;
-  constructor(value: ArrayInputParameters) {
-    super('ArrayInput', value);
+export class ArrayKind extends Kind {
+  declare param: Kind;
+  constructor(value: ArrayKindParameters) {
+    super('ArrayKind', value);
   }
 }
 
-Schema.register('ArrayInput', ArrayInput);
+Schema.register('ArrayKind', ArrayKind);
 
-type EnumInputParameters = {
+type EnumKindParameters = {
   values: Record<string, string>;
 };
 
-export class EnumInput extends Input {
+export class EnumKind extends Kind {
   declare values: Record<string, string>;
-  constructor(value: EnumInputParameters) {
-    super('EnumInput', value);
+  constructor(value: EnumKindParameters) {
+    super('EnumKind', value);
   }
 }
 
-Schema.register('EnumInput', EnumInput);
+Schema.register('EnumKind', EnumKind);
 
 type ExpressionParameters = {
   meta?: Record<string, any>;
@@ -153,12 +153,12 @@ type ValParameters = {
   meta?: Record<string, any>;
   name: string;
   init: Expression;
-  input?: Input | null;
+  kind?: Kind | null;
 };
 
 export class Val extends Variable {
   declare init: Expression;
-  declare input: Input | null;
+  declare kind: Kind | null;
   constructor(value: ValParameters) {
     super('Val', value);
   }
@@ -356,12 +356,12 @@ type ComponentPropParameters = {
   meta?: Record<string, any>;
   name: string;
   init?: Expression | null;
-  input?: Input | null;
+  kind?: Kind | null;
 };
 
 export class ComponentProp extends Variable {
   declare init: Expression | null;
-  declare input: Input | null;
+  declare kind: Kind | null;
   constructor(value: ComponentPropParameters) {
     super('ComponentProp', value);
   }
@@ -780,10 +780,10 @@ export type Any =
   | State
   | ASTNode
   | Program
-  | Input
-  | PrimitiveInput
-  | ArrayInput
-  | EnumInput
+  | Kind
+  | PrimitiveKind
+  | ArrayKind
+  | EnumKind
   | Expression
   | Variable
   | Literal
@@ -828,10 +828,10 @@ export type Visitor = {
   State: (node: State) => any;
   ASTNode: (node: ASTNode) => any;
   Program: (node: Program) => any;
-  Input: (node: Input) => any;
-  PrimitiveInput: (node: PrimitiveInput) => any;
-  ArrayInput: (node: ArrayInput) => any;
-  EnumInput: (node: EnumInput) => any;
+  Kind: (node: Kind) => any;
+  PrimitiveKind: (node: PrimitiveKind) => any;
+  ArrayKind: (node: ArrayKind) => any;
+  EnumKind: (node: EnumKind) => any;
   Expression: (node: Expression) => any;
   Variable: (node: Variable) => any;
   Literal: (node: Literal) => any;

--- a/packages/types/src/types.definition.ts
+++ b/packages/types/src/types.definition.ts
@@ -37,7 +37,7 @@ Schema.define('PrimitiveKind', {
 Schema.define('ArrayKind', {
   extends: 'Kind',
   fields: (t) => ({
-    param: t.node('Kind'),
+    kind: t.node('Kind'),
   }),
 });
 

--- a/packages/types/src/types.definition.ts
+++ b/packages/types/src/types.definition.ts
@@ -41,10 +41,10 @@ Schema.define('ArrayKind', {
   }),
 });
 
-Schema.define('EnumKind', {
+Schema.define('OptionKind', {
   extends: 'Kind',
   fields: (t) => ({
-    values: t.map(t.string),
+    options: t.map(t.string),
   }),
 });
 

--- a/packages/types/src/types.definition.ts
+++ b/packages/types/src/types.definition.ts
@@ -23,6 +23,31 @@ Schema.define('Program', {
   }),
 });
 
+Schema.define('Input', {
+  abstract: true,
+});
+
+Schema.define('PrimitiveInput', {
+  extends: 'Input',
+  fields: (t) => ({
+    kind: t.enumeration('string', 'number', 'boolean'),
+  }),
+});
+
+Schema.define('ArrayInput', {
+  extends: 'Input',
+  fields: (t) => ({
+    param: t.node('Input'),
+  }),
+});
+
+Schema.define('EnumInput', {
+  extends: 'Input',
+  fields: (t) => ({
+    values: t.map(t.string),
+  }),
+});
+
 Schema.define('Expression', {
   extends: 'ASTNode',
   abstract: true,
@@ -55,6 +80,7 @@ Schema.define('Val', {
   extends: 'Variable',
   fields: (t) => ({
     init: t.node('Expression'),
+    input: t.optional(t.node('Input')),
   }),
 });
 
@@ -164,6 +190,7 @@ Schema.define('ComponentProp', {
   extends: 'Variable',
   fields: (t) => ({
     init: t.defaultValue(t.union(t.node('Expression'), t.nullish), null),
+    input: t.optional(t.node('Input')),
   }),
 });
 

--- a/packages/types/src/types.definition.ts
+++ b/packages/types/src/types.definition.ts
@@ -23,26 +23,26 @@ Schema.define('Program', {
   }),
 });
 
-Schema.define('Input', {
+Schema.define('Kind', {
   abstract: true,
 });
 
-Schema.define('PrimitiveInput', {
-  extends: 'Input',
+Schema.define('PrimitiveKind', {
+  extends: 'Kind',
   fields: (t) => ({
-    kind: t.enumeration('string', 'number', 'boolean'),
+    primitive: t.enumeration('string', 'number', 'boolean'),
   }),
 });
 
-Schema.define('ArrayInput', {
-  extends: 'Input',
+Schema.define('ArrayKind', {
+  extends: 'Kind',
   fields: (t) => ({
-    param: t.node('Input'),
+    param: t.node('Kind'),
   }),
 });
 
-Schema.define('EnumInput', {
-  extends: 'Input',
+Schema.define('EnumKind', {
+  extends: 'Kind',
   fields: (t) => ({
     values: t.map(t.string),
   }),
@@ -80,7 +80,7 @@ Schema.define('Val', {
   extends: 'Variable',
   fields: (t) => ({
     init: t.node('Expression'),
-    input: t.optional(t.node('Input')),
+    kind: t.optional(t.node('Kind')),
   }),
 });
 
@@ -190,7 +190,7 @@ Schema.define('ComponentProp', {
   extends: 'Variable',
   fields: (t) => ({
     init: t.defaultValue(t.union(t.node('Expression'), t.nullish), null),
-    input: t.optional(t.node('Input')),
+    kind: t.optional(t.node('Kind')),
   }),
 });
 


### PR DESCRIPTION
This PR is added as an requirement for Craft.js

## Background

When building page builder UIs with Craft.js, we would want to be able to show the appropriate UI to the end-user when they're creating and using a state variable/component prop. 

For example, when the user is designing a "Button" component, they may want to add a `color` prop which is of type string. Then, since the `color` prop is of type `string`, the UI should display a textbox where the end-user could specify an default value. Similarly, when the end-user references this "Button" component elsewhere, the UI should display a textbox to allow the end-user to specify the value for the `color` prop in the component's template.

Currently, all state variables/component props in Reka are essentially of type `any` and therefore it's quite difficult to build more specific UIs to help the end-user.

<img width="1227" alt="Screenshot 2023-08-01 at 6 11 09 PM" src="https://github.com/prevwong/reka.js/assets/16416929/ed96ef1c-ed7e-4a80-a202-28ea16a0e5c4">

## Changes

This PR introduces the ability to specific an explicit `kind` when defining state variables/component props in the AST:

```
val counter: number = 0;
val str: string = "blue";
val selection: option<{ blue: "Blue", red: "Red" }> = "red";

component Button(color: string = "blue" ) {} => (...)
```


## Future

### Validation 

This feature should allow us to perform input validation on runtime. For example, if a Button component accepts a `color` prop that's of type `string` but the user passes a `number` instead, we could display an error instead of trying to further evaluate the component which probably would have some unwanted behaviour if we evaluate it with the erroneous prop value.

### Custom Models

On top of the primitive/array/option `kind` implemented in this PR, we could possibly allow the use of custom object models:

```tsx
t.program({
   models: [
      t.model({
         name: "post",
         fields: {
             title: t.primitiveKind({ primitive: "string" }),
          }
      })
   ],
   globals: [
       t.val({
          name: "posts",
          kind: t.arrayKind({ kind: t.modelKind({ model: "post" }) })
       })  
   ]
})
```

