### PR TITLE
feat: improve member expression

### DIFF
--- a/.changeset/smooth-planets-sell.md
+++ b/.changeset/smooth-planets-sell.md
@@ -1,0 +1,7 @@
+---
+'@rekajs/parser': patch
+'@rekajs/types': patch
+'@rekajs/core': patch
+---
+
+Improve member expression type and enable assignments on member expressions

--- a/packages/core/src/tests/evaluator.test.ts
+++ b/packages/core/src/tests/evaluator.test.ts
@@ -173,6 +173,29 @@ describe('evaluator', () => {
 
       expect(view.props['value']).toEqual(2);
     });
+    it('should be able to manipulate member expression', async () => {
+      const frame = await createFrame(`
+        component App() {
+          val table = {
+            items: [2,3,4]
+          };
+        } => (
+          <button value={table['items'][1]} onClick={() => {
+            table.items[1] = 99;
+          }} />
+        )
+      `);
+
+      const view = t.assert(frame.view, t.RekaComponentView, (view) => {
+        return t.assert(view.render[0], t.TagView);
+      });
+
+      expect(view.props['value']).toEqual(3);
+
+      await view.props['onClick']();
+
+      expect(view.props['value']).toEqual(99);
+    });
   });
 
   it('should not dispose component evaluation when child template order is changed', async () => {

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -62,6 +62,23 @@ const getJSObjFromExpr = (obj: b.ObjectExpression) => {
   }, {});
 };
 
+const convertMemberExpression = (expr: b.MemberExpression) => {
+  let property: t.Expression;
+
+  if (b.isIdentifier(expr.property) && !expr.computed) {
+    property = t.literal({
+      value: expr.property.name,
+    });
+  } else {
+    property = jsToReka(expr.property);
+  }
+
+  return t.memberExpression({
+    object: jsToReka(expr.object),
+    property,
+  });
+};
+
 const jsToReka = <T extends t.ASTNode = t.ASTNode>(
   node: b.Node,
   opts?: AcornParserOptions<T>
@@ -264,10 +281,7 @@ const jsToReka = <T extends t.ASTNode = t.ASTNode>(
         return t.Schema.fromJSON(node.expression);
       }
       case 'MemberExpression': {
-        return t.memberExpression({
-          object: _convert(node.object),
-          property: _convert(node.property),
-        });
+        return convertMemberExpression(node);
       }
       default: {
         return t.Schema.fromJSON(node) as t.Type;

--- a/packages/parser/src/tests/parser.test.ts
+++ b/packages/parser/src/tests/parser.test.ts
@@ -32,9 +32,48 @@ describe('Parser', () => {
         external: false,
       },
       property: {
+        type: 'Literal',
+        value: 'prop',
+      },
+    });
+
+    expect(Parser.parseExpression(`obj.prop[0]`)).toMatchObject({
+      type: 'MemberExpression',
+      object: {
+        type: 'MemberExpression',
+        object: {
+          type: 'Identifier',
+          name: 'obj',
+          external: false,
+        },
+        property: {
+          type: 'Literal',
+          value: 'prop',
+        },
+      },
+      property: {
+        type: 'Literal',
+        value: 0,
+      },
+    });
+
+    expect(Parser.parseExpression(`obj.prop[idx]`)).toMatchObject({
+      type: 'MemberExpression',
+      object: {
+        type: 'MemberExpression',
+        object: {
+          type: 'Identifier',
+          name: 'obj',
+          external: false,
+        },
+        property: {
+          type: 'Literal',
+          value: 'prop',
+        },
+      },
+      property: {
         type: 'Identifier',
-        name: 'prop',
-        external: false,
+        name: 'idx',
       },
     });
 
@@ -46,9 +85,8 @@ describe('Parser', () => {
         external: true,
       },
       property: {
-        type: 'Identifier',
-        name: 'prop',
-        external: false,
+        type: 'Literal',
+        value: 'prop',
       },
     });
   });

--- a/packages/types/src/generated/types.generated.ts
+++ b/packages/types/src/generated/types.generated.ts
@@ -324,13 +324,13 @@ Schema.register('IfStatement', IfStatement);
 
 type AssignmentParameters = {
   meta?: Record<string, any>;
-  left: Identifier;
+  left: Identifier | MemberExpression;
   operator: '=' | '+=' | '-=' | '*=' | '/=' | '^=' | '%=';
   right: Expression;
 };
 
 export class Assignment extends Expression {
-  declare left: Identifier;
+  declare left: Identifier | MemberExpression;
   declare operator: '=' | '+=' | '-=' | '*=' | '/=' | '^=' | '%=';
   declare right: Expression;
   constructor(value: AssignmentParameters) {

--- a/packages/types/src/types.definition.ts
+++ b/packages/types/src/types.definition.ts
@@ -174,7 +174,7 @@ Schema.define('Assignment', {
   extends: 'Expression',
   alias: ['Statement'],
   fields: (t) => ({
-    left: t.node('Identifier'),
+    left: t.union(t.node('Identifier'), t.node('MemberExpression')),
     operator: t.enumeration('=', '+=', '-=', '*=', '/=', '^=', '%='),
     right: t.node('Expression'),
   }),

--- a/packages/types/src/utils.ts
+++ b/packages/types/src/utils.ts
@@ -345,3 +345,13 @@ export function assert<T extends Type, C extends (value: T) => any>(
 
   return value;
 }
+
+export const getRootIdentifierInMemberExpression = (
+  expr: t.MemberExpression
+): t.Identifier => {
+  if (t.is(expr.object, t.Identifier)) {
+    return expr.object;
+  }
+
+  return getRootIdentifierInMemberExpression(expr.object);
+};


### PR DESCRIPTION
This PR introduces some improvements on member expressions:

1. Allows Assignment operations to be done on member expressions:
```tsx
obj[0] = 99;
```

2. Simplifies member expressions AST node:

```tsx
// If we are attempting to access a property in an object by a known key:
obj.prop // treated the same as obj["prop"]

{
  type: "MemberExpression",
  object: { type: "Identifier", name: "obj" },
  // "prop" is now treated as a Literal, prior to this PR - this would be an Identifier
  property: { type: "Literal", value: "prop" }
}
```

```tsx
// If we are attempting to access a property in an object via a dynamic value:
obj[prop] // where prop is some variable

{
  type: "MemberExpression",
  object: { type: "Identifier", name: "obj" }
  property: { type: "Identifier", value: "prop" }
}
```