### PR TITLE
fix: cache root template evaluation

### DIFF
--- a/.changeset/angry-birds-attack.md
+++ b/.changeset/angry-birds-attack.md
@@ -1,0 +1,5 @@
+---
+'@rekajs/core': patch
+---
+
+Cache root template in component evaluation


### PR DESCRIPTION
Ensures root template computation is cached to prevent unnecessary re-evaluation 