### PR TITLE
feat: add ability to specify computed properties on data types

### DIFF
--- a/.changeset/brown-years-kneel.md
+++ b/.changeset/brown-years-kneel.md
@@ -1,0 +1,6 @@
+---
+'@rekajs/types': patch
+'@rekajs/core': patch
+---
+
+Add ability to specify computed properties on Reka data types

--- a/packages/core/src/reka.ts
+++ b/packages/core/src/reka.ts
@@ -206,6 +206,13 @@ export class Reka {
           this.head.resolver.cleanupDisposedNode(payload.type);
         },
       },
+      resolveProp: (node, name) => {
+        if (t.is(node, t.Identifier) && name === 'identifiable') {
+          return this.getIdentifiableFromIdentifier(node);
+        }
+
+        return null;
+      },
     });
 
     this.setHistoryManager(new DefaultHistoryManager(this));

--- a/packages/types/scripts/generator/index.js
+++ b/packages/types/scripts/generator/index.js
@@ -80,6 +80,14 @@ for (const type in Schema.getRegistry()) {
     constructor(${constructorArgs.join(',')}) {
       super(${superCtorParams.join(',')})
     }
+
+    ${Object.entries(schema.annotations).map(
+      ([name, annotation]) => `
+        get ${name}(): ${stringifyField(annotation.type)} | null {
+          return Schema.computeAnnotatedProp(this, "${name}");
+        }
+      `
+    )}
   }
   
 

--- a/packages/types/scripts/generator/index.js
+++ b/packages/types/scripts/generator/index.js
@@ -83,7 +83,7 @@ for (const type in Schema.getRegistry()) {
 
     ${Object.entries(schema.annotations).map(
       ([name, annotation]) => `
-        get ${name}(): ${stringifyField(annotation.type)} | null {
+        get ${name}(): ${stringifyField(annotation.type)} {
           return Schema.computeAnnotatedProp(this, "${name}");
         }
       `

--- a/packages/types/src/annotations/annotation.ts
+++ b/packages/types/src/annotations/annotation.ts
@@ -1,0 +1,25 @@
+import { Type } from '../node';
+import { Validator, assertions } from '../validators';
+
+/**
+ * Annotations are used to specify getter/computed properties on a Type
+ */
+export abstract class Annotation {
+  readonly name: string;
+  readonly type: Validator;
+
+  constructor(name: string, validator: Validator) {
+    this.name = name;
+    this.type = assertions.optional(validator);
+  }
+
+  abstract compute(node: Type, field: string): any;
+
+  get(node: Type, field: string) {
+    const value = this.compute(node, field);
+
+    return this.type.get(value, {
+      clone: false,
+    });
+  }
+}

--- a/packages/types/src/annotations/builders.ts
+++ b/packages/types/src/annotations/builders.ts
@@ -1,0 +1,6 @@
+import { ResolvePropAnnotation } from './definitions';
+
+import { Validator } from '../validators';
+
+export const resolveProp = (validator: Validator) =>
+  new ResolvePropAnnotation(validator);

--- a/packages/types/src/annotations/definitions.ts
+++ b/packages/types/src/annotations/definitions.ts
@@ -1,0 +1,23 @@
+import { Annotation } from './annotation';
+
+import { Type, Tree } from '../node';
+import { Validator } from '../validators';
+
+/**
+ * Specify that a computed field on a Type should be resolved by it's parent Tree
+ */
+export class ResolvePropAnnotation extends Annotation {
+  constructor(validator: Validator) {
+    super('resolve-prop', validator);
+  }
+
+  compute(node: Type, field: string) {
+    const tree = Tree.getNodeTree(node);
+
+    if (!tree) {
+      return null;
+    }
+
+    return tree.resolveProp(node, field);
+  }
+}

--- a/packages/types/src/annotations/index.ts
+++ b/packages/types/src/annotations/index.ts
@@ -1,0 +1,2 @@
+export * from './annotation';
+export * as annotations from './builders';

--- a/packages/types/src/generated/types.generated.ts
+++ b/packages/types/src/generated/types.generated.ts
@@ -305,6 +305,10 @@ export class Identifier extends Expression {
   ) {
     super('Identifier', value, opts);
   }
+
+  get identifiable(): Identifiable | null | null {
+    return Schema.computeAnnotatedProp(this, 'identifiable');
+  }
 }
 
 Schema.register('Identifier', Identifier);

--- a/packages/types/src/generated/types.generated.ts
+++ b/packages/types/src/generated/types.generated.ts
@@ -306,7 +306,7 @@ export class Identifier extends Expression {
     super('Identifier', value, opts);
   }
 
-  get identifiable(): Identifiable | null | null {
+  get identifiable(): Identifiable | null {
     return Schema.computeAnnotatedProp(this, 'identifiable');
   }
 }

--- a/packages/types/src/node/index.ts
+++ b/packages/types/src/node/index.ts
@@ -1,1 +1,2 @@
 export * from './type';
+export * from './tree';

--- a/packages/types/src/node/tree.ts
+++ b/packages/types/src/node/tree.ts
@@ -1,0 +1,40 @@
+import { invariant } from '@rekajs/utils';
+
+import { Type } from './type';
+
+const NodeTreeSymbol = Symbol('RekaNodeTree');
+
+/**
+ * @internal
+ */
+export abstract class Tree {
+  readonly id: string;
+  readonly root: Type;
+
+  constructor(id: string, root: Type) {
+    this.id = id;
+    this.root = root;
+  }
+
+  abstract resolveProp(node: Type, name: string): any;
+
+  addNodeToTree(node: Type) {
+    Tree.setNodeTree(node, this);
+  }
+
+  static getNodeTree(node: Type) {
+    return node[NodeTreeSymbol];
+  }
+
+  static setNodeTree(node: Type, tree: Tree) {
+    const existingNodeTree = Tree.getNodeTree(node);
+
+    // Don't allow nodes to be used across multiple tree, as it can lead to bugs
+    invariant(
+      !existingNodeTree || existingNodeTree === tree,
+      `${node.type}<${node.id}> is already part of a different Tree<${tree.id}>.`
+    );
+
+    node[NodeTreeSymbol] = tree;
+  }
+}

--- a/packages/types/src/schema/index.ts
+++ b/packages/types/src/schema/index.ts
@@ -1,1 +1,1 @@
-export * from './Schema';
+export * from './schema';

--- a/packages/types/src/types.definition.ts
+++ b/packages/types/src/types.definition.ts
@@ -105,6 +105,9 @@ Schema.define('Identifier', {
     name: t.string,
     external: t.defaultValue(t.boolean, false),
   }),
+  annotations: (a, t) => ({
+    identifiable: a.resolveProp(t.node('Identifiable')),
+  }),
 });
 
 Schema.define('Val', {

--- a/packages/types/src/types.docs.ts
+++ b/packages/types/src/types.docs.ts
@@ -1,6 +1,6 @@
 /**
  * This file exists so getdocs-ts could get all other relevant classes for the document page
  */
-export * from './node';
+export { Type } from './node';
 export * from './generated/types.generated';
 export * from './utils';


### PR DESCRIPTION
This PR allows Reka data types (ie: the AST) to be able to specify getter/computed properties. 

Currently this is useful as it allows us to specify a computed property on the `Identifier` node where consumers can easily access the actual variable that `Identifier` node is referencing:

```
component App() {
  val counter = 0;
} => (
  <text value={counter} />
)
```

Let's say we want to know the variable that the `Identifier` node in the text's value prop is referencing. We can now do the following:
```tsx
const appComponent = reka.program.components.find(component => component.name === "App");

const counterIdentifier = t.assert(appComponent.template.props.value, t.Identifier);

console.log(counterIdentifier.identifiable); // { type: "Val", name: "counter", init: { ... } }
```