### PR TITLE
bug fix: Fix empty frame name and props

### DIFF
--- a/site/components/editor-layout/AddFrameModal.tsx
+++ b/site/components/editor-layout/AddFrameModal.tsx
@@ -97,6 +97,15 @@ export const AddFrameModal = (props: AddFrameModalProps) => {
                   };
                 });
               }}
+              onRemove={(id) => {
+                setComponentProps((props) => {
+                  delete props[id];
+
+                  return {
+                    ...props,
+                  };
+                });
+              }}
               values={Object.keys(componentProps).reduce((accum, propKey) => {
                 return [
                   ...accum,

--- a/site/components/editor-layout/AddFrameModal.tsx
+++ b/site/components/editor-layout/AddFrameModal.tsx
@@ -76,6 +76,7 @@ export const AddFrameModal = (props: AddFrameModalProps) => {
             <TextField
               placeholder="Frame #1"
               value={frameName}
+              required
               onChange={(e) => {
                 setFrameName(e.target.value);
               }}
@@ -113,6 +114,10 @@ export const AddFrameModal = (props: AddFrameModalProps) => {
         <Button
           variant="primary"
           onClick={() => {
+            if (!frameName) {
+              return;
+            }
+
             editor.reka.change(() => {
               if (!existingFrame) {
                 editor.reka.getExtension(UserFrameExtension).state.frames.push({
@@ -126,6 +131,9 @@ export const AddFrameModal = (props: AddFrameModalProps) => {
 
               existingFrame.props = componentProps;
             });
+
+            // clean up the form
+            setFrameName('');
 
             editor.activeComponentEditor?.setActiveFrame(frameName);
 

--- a/site/components/text-field/index.tsx
+++ b/site/components/text-field/index.tsx
@@ -30,12 +30,20 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
       onCommit,
       onChange,
       value,
+      required,
       ...props
     },
     ref
   ) => {
     const [uncommittedValue, setUncommitedValue] = React.useState(value);
     const [hasError, setHasError] = React.useState('');
+
+    // handle `required` attribute
+    React.useEffect(() => {
+      if (required && !value && !uncommittedValue && !hasError) {
+        setHasError('A value is required for this field');
+      }
+    }, [required, value, uncommittedValue, hasError]);
 
     const commitValue = () => {
       if (!onCommit) {
@@ -65,7 +73,7 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
     return (
       <div
         className={cn(
-          'group flex-1 relative border border-solid border-outline flex items-center rounded-md shadow-sm',
+          'group flex-1 flex-col relative border border-solid border-outline flex items-center rounded-md shadow-sm',
           {
             'border-red-400': !!hasError,
             'border-none': transparent,
@@ -124,7 +132,7 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
           </IconButton>
         )}
         {hasError && (
-          <div className="absolute left-0 top-full w-full text-xs px-3 py-3 bg-red-300 text-white z-2">
+          <div className="left-0 top-full w-full text-xs px-3 py-3 bg-red-300 text-white z-2">
             {hasError}
           </div>
         )}


### PR DESCRIPTION
- creating a frame without specifying it's name bugs the editor as the frame name is used as it's ID
- cannot remove "create frame" modal props after adding any