### PR TITLE
Pass down the scope to named slots

### DIFF
--- a/packages/core/src/resolver.ts
+++ b/packages/core/src/resolver.ts
@@ -396,6 +396,11 @@ export class Resolver {
             template.children.forEach((child) => {
               this.resolveTemplate(child, templateScope);
             });
+            Object.values(template.slots).map((children) =>
+              children.map((child) =>
+                this.resolveTemplate(child, templateScope)
+              )
+            );
           }
         }),
       };


### PR DESCRIPTION
You can put the counter variable inside a named slot to see it stops working.